### PR TITLE
Load formatting settings from pyproject.toml

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,7 @@ repositories {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
+    implementation "com.moandjiezana.toml:toml4j:0.7.2"
     testImplementation group: 'junit', name: 'junit', version: '4.12'
 }
 

--- a/src/main/java/me/lensvol/blackconnect/config/BlackConnectConfigurable.kt
+++ b/src/main/java/me/lensvol/blackconnect/config/BlackConnectConfigurable.kt
@@ -7,7 +7,7 @@ import javax.swing.JComponent
 
 class BlackConnectConfigurable(project: Project) : Configurable {
     private val panel: BlackConnectSettingsPanel by lazy {
-        BlackConnectSettingsPanel()
+        BlackConnectSettingsPanel(project)
     }
 
     private val configuration: BlackConnectProjectSettings =

--- a/src/main/java/me/lensvol/blackconnect/config/BlackConnectSettingsPanel.kt
+++ b/src/main/java/me/lensvol/blackconnect/config/BlackConnectSettingsPanel.kt
@@ -68,11 +68,8 @@ class BlackConnectSettingsPanel(project: Project) : JPanel() {
         loadPyprojectTomlButton.isEnabled = true
         loadPyprojectTomlButton.addActionListener {
             val pyprojectTomlDescriptor = createPyprojectSpecificDescriptor()
-            val candidates = FileBasedIndex.getInstance().getContainingFiles(
-                FilenameIndex.NAME,
-                "pyproject.toml",
-                GlobalSearchScope.allScope(project)
-            )
+            val candidates =
+                FilenameIndex.getVirtualFilesByName(project, "pyproject.toml", GlobalSearchScope.projectScope(project))
 
             FileChooser.chooseFile(pyprojectTomlDescriptor, project, parent, candidates.firstOrNull()) { file ->
                 val contents = file.inputStream.bufferedReader().use(BufferedReader::readText)

--- a/src/main/java/me/lensvol/blackconnect/config/BlackConnectSettingsPanel.kt
+++ b/src/main/java/me/lensvol/blackconnect/config/BlackConnectSettingsPanel.kt
@@ -4,6 +4,7 @@ import com.intellij.openapi.fileChooser.FileChooser
 import com.intellij.openapi.fileChooser.FileChooserDescriptor
 import com.intellij.openapi.fileChooser.FileElement
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.ui.Messages
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.psi.search.FilenameIndex
 import com.intellij.psi.search.GlobalSearchScope
@@ -28,7 +29,7 @@ import javax.swing.JTextField
 import javax.swing.SpinnerNumberModel
 
 const val PYPROJECT_TOML: String = "pyproject.toml"
-const val DEFAULT_LINE_LENGTH: Long = 88
+const val DEFAULT_LINE_LENGTH: Int = 88
 const val DEFAULT_BLACKD_PORT: Int = 45484
 
 class BlackConnectSettingsPanel(project: Project) : JPanel() {
@@ -197,12 +198,13 @@ class BlackConnectSettingsPanel(project: Project) : JPanel() {
     private fun processPyprojectToml(tomlContents: String) {
         val toml: Toml = Toml().read(tomlContents)
         if (!toml.contains("tool.black")) {
+            Messages.showErrorDialog(this, "<b>[tool.black]</b> section not found!", "Error")
             return
         }
 
         val blackSettings = toml.getTable("tool.black")
         lineLengthSpinner.value =
-            blackSettings.getLong("line-length", DEFAULT_LINE_LENGTH).toInt()
+            blackSettings.getLong("line-length", DEFAULT_LINE_LENGTH.toLong()).toInt()
         val targetVersionsFromFile = blackSettings.getList<String>("target-version", Collections.emptyList())
         if (targetVersionsFromFile.count() > 0) {
             targetSpecificVersionsCheckbox.isSelected = true

--- a/src/main/java/me/lensvol/blackconnect/config/BlackConnectSettingsPanel.kt
+++ b/src/main/java/me/lensvol/blackconnect/config/BlackConnectSettingsPanel.kt
@@ -8,7 +8,6 @@ import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.psi.search.FilenameIndex
 import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.ui.IdeBorderFactory
-import com.intellij.util.indexing.FileBasedIndex
 import com.intellij.util.ui.FormBuilder
 import com.intellij.util.ui.JBUI
 import com.intellij.util.ui.UIUtil
@@ -28,13 +27,17 @@ import javax.swing.JSpinner
 import javax.swing.JTextField
 import javax.swing.SpinnerNumberModel
 
+const val PYPROJECT_TOML: String = "pyproject.toml"
+const val DEFAULT_LINE_LENGTH: Long = 88
+const val DEFAULT_BLACKD_PORT: Int = 45484
+
 class BlackConnectSettingsPanel(project: Project) : JPanel() {
     private val hostnameText = JTextField("127.0.0.1")
 
-    private val portSpinnerModel = SpinnerNumberModel(45484, 1, 65535, 1)
+    private val portSpinnerModel = SpinnerNumberModel(DEFAULT_BLACKD_PORT, 1, 65535, 1)
     private val portSpinner = JSpinner(portSpinnerModel)
 
-    private val lineLengthModel = SpinnerNumberModel(88, 45, 255, 1)
+    private val lineLengthModel = SpinnerNumberModel(DEFAULT_LINE_LENGTH, 45, 255, 1)
     private val lineLengthSpinner = JSpinner(lineLengthModel)
 
     private val fastModeCheckbox = JCheckBox("Skip sanity checks")
@@ -172,7 +175,7 @@ class BlackConnectSettingsPanel(project: Project) : JPanel() {
     private fun createPyprojectSpecificDescriptor(): FileChooserDescriptor {
         val fileSpecificDescriptor = object : FileChooserDescriptor(true, false, false, false, false, false) {
             override fun isFileSelectable(file: VirtualFile?): Boolean {
-                return super.isFileSelectable(file) && file?.name.equals("pyproject.toml")
+                return super.isFileSelectable(file) && file?.name.equals(PYPROJECT_TOML)
             }
 
             override fun isFileVisible(file: VirtualFile?, showHiddenFiles: Boolean): Boolean {
@@ -184,7 +187,7 @@ class BlackConnectSettingsPanel(project: Project) : JPanel() {
                     return false
                 }
 
-                return file.isDirectory || file.name == "pyproject.toml"
+                return file.isDirectory || file.name == PYPROJECT_TOML
             }
         }
         fileSpecificDescriptor.isForcedToUseIdeaFileChooser = true
@@ -199,7 +202,7 @@ class BlackConnectSettingsPanel(project: Project) : JPanel() {
 
         val blackSettings = toml.getTable("tool.black")
         lineLengthSpinner.value =
-            blackSettings.getLong("line-length", 88).toInt()
+            blackSettings.getLong("line-length", DEFAULT_LINE_LENGTH).toInt()
         val targetVersionsFromFile = blackSettings.getList<String>("target-version", Collections.emptyList())
         if (targetVersionsFromFile.count() > 0) {
             targetSpecificVersionsCheckbox.isSelected = true


### PR DESCRIPTION
_**Black**_ [allows](https://black.readthedocs.io/en/stable/pyproject_toml.html) you to specify its settings in **[tool.black]** section of the `pyproject.toml`. This saves time when using it and gives you an opportunity to set up formatting in a way that is shared by everyone working on the project.

This MR adds the capability to load a limited set of formatting options from `pyproject.toml` (everything except for _include_ and _exclude_).