### PR TITLE
Support new Black version 21.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Instead, on each press of `Alt + Shift + B` plugin will send contents of the cur
     * Preferred line length (default: 88).
     * Skipping sanity checks ("fast mode").
     * Skipping string normalization.
+    * Processing of "magic trailing comma" in collections.
     * Target specific Python versions.
 
 ## Installation

--- a/src/main/kotlin/me/lensvol/blackconnect/BlackdClient.kt
+++ b/src/main/kotlin/me/lensvol/blackconnect/BlackdClient.kt
@@ -66,6 +66,7 @@ class BlackdClient(hostname: String, port: Int, useSsl: Boolean = false) {
         lineLength: Int = 88,
         fastMode: Boolean = false,
         skipStringNormalization: Boolean = false,
+        skipMagicTrailingComma: Boolean = false,
         targetPythonVersions: String = ""
     ): Result<BlackdResponse, String> {
 
@@ -87,6 +88,10 @@ class BlackdClient(hostname: String, port: Int, useSsl: Boolean = false) {
 
             if (skipStringNormalization) {
                 setRequestProperty("X-Skip-String-Normalization", "yes")
+            }
+
+            if (skipMagicTrailingComma) {
+                setRequestProperty("X-Skip-Magic-Trailing-Comma", "yes")
             }
 
             return try {

--- a/src/main/kotlin/me/lensvol/blackconnect/BlackdClient.kt
+++ b/src/main/kotlin/me/lensvol/blackconnect/BlackdClient.kt
@@ -135,7 +135,8 @@ class BlackdClient(hostname: String, port: Int, useSsl: Boolean = false) {
                 if (errorText.startsWith("Cannot parse")) {
                     logger.debug("400: Code contained syntax errors.")
                     BlackdResponse.SyntaxError(errorText)
-                } else {
+                }
+                else {
                     logger.debug("400: Invalid request was sent:\n$errorText")
                     BlackdResponse.InvalidRequest(errorText)
                 }

--- a/src/main/kotlin/me/lensvol/blackconnect/CodeReformatter.kt
+++ b/src/main/kotlin/me/lensvol/blackconnect/CodeReformatter.kt
@@ -148,6 +148,7 @@ open class CodeReformatter(project: Project) {
             lineLength = configuration.lineLength,
             fastMode = configuration.fastMode,
             skipStringNormalization = configuration.skipStringNormalization,
+            skipMagicTrailingComma = configuration.skipMagicTrailingComma,
             targetPythonVersions = if (configuration.targetSpecificVersions) configuration.pythonTargets else ""
         )
 

--- a/src/main/kotlin/me/lensvol/blackconnect/actions/ReformatWholeFileAction.kt
+++ b/src/main/kotlin/me/lensvol/blackconnect/actions/ReformatWholeFileAction.kt
@@ -62,11 +62,28 @@ class ReformatWholeFileAction : AnAction(), DumbAware {
                     is BlackdResponse.UnknownStatus -> notificationService.showError(
                         "Something unexpected happened:<br>${response.responseText}"
                     )
-                    is BlackdResponse.InvalidRequest -> notificationService.showError(
-                        "Server did not understand our request.<br>Maybe you need to connect over SSL?",
-                        viewPromptText = "View response",
-                        additionalInfo = response.reason
-                    )
+                    is BlackdResponse.InvalidRequest -> {
+                        /*
+                        Sadly, blackd does not reply with easily parseable error codes, so we have to implement
+                        crude error detection heuristics here. This one specifically looks for unsupported
+                        target versions, as different versions of blackd may have different sets of them.
+                         */
+                        if(response.reason.startsWith("Invalid value for X-Python-Variant")) {
+                            val startPos = response.reason.indexOf(": ")
+                            val endPos = response.reason.indexOf(" is not supported")
+                            val unsupportedVersion = response.reason.slice(startPos+2..endPos)
+
+                            notificationService.showError(
+                                "Your version of <b>blackd</b> does not support targeting Python <b>${unsupportedVersion}</b>.",
+                            )
+                        } else {
+                            notificationService.showError(
+                                "Server did not understand our request.<br>Maybe you need to connect over SSL?",
+                                viewPromptText = "View response",
+                                additionalInfo = response.reason
+                            )
+                        }
+                    }
                 }
             }
         }

--- a/src/main/kotlin/me/lensvol/blackconnect/config/sections/FormattingSection.kt
+++ b/src/main/kotlin/me/lensvol/blackconnect/config/sections/FormattingSection.kt
@@ -35,7 +35,7 @@ class FormattingSection(private val project: Project) : ConfigSection(project) {
 
     private val fastModeCheckbox = JCheckBox("Skip sanity checks")
     private val skipStringNormalCheckbox = JCheckBox("Skip string normalization")
-    private val skipMagicTrailingCommaCheckbox = JCheckBox("Don't use trailing commas as a reason to split lines.")
+    private val skipMagicTrailingCommaCheckbox = JCheckBox("Don't use trailing commas as a reason to split lines")
     private val targetSpecificVersionsCheckbox = JCheckBox("Target specific Python versions")
 
     private val targetVersions = linkedMapOf(

--- a/src/main/kotlin/me/lensvol/blackconnect/config/sections/FormattingSection.kt
+++ b/src/main/kotlin/me/lensvol/blackconnect/config/sections/FormattingSection.kt
@@ -38,17 +38,18 @@ class FormattingSection(private val project: Project) : ConfigSection(project) {
     private val skipMagicTrailingCommaCheckbox = JCheckBox("Don't use trailing commas as a reason to split lines.")
     private val targetSpecificVersionsCheckbox = JCheckBox("Target specific Python versions")
 
-    private val targetVersions = mapOf(
+    private val targetVersions = linkedMapOf(
         "py27" to "2.7",
         "py33" to "3.3",
         "py34" to "3.4",
         "py35" to "3.5",
         "py36" to "3.6",
         "py37" to "3.7",
-        "py38" to "3.8"
+        "py38" to "3.8",
+        "py39" to "3.9"
     )
 
-    private val versionCheckboxes = sortedMapOf<String, JCheckBox>().apply {
+    private val versionCheckboxes = linkedMapOf<String, JCheckBox>().apply {
         targetVersions.values.map { version ->
             this.put("py$version", JCheckBox(version))
         }

--- a/src/main/kotlin/me/lensvol/blackconnect/config/sections/FormattingSection.kt
+++ b/src/main/kotlin/me/lensvol/blackconnect/config/sections/FormattingSection.kt
@@ -35,6 +35,7 @@ class FormattingSection(private val project: Project) : ConfigSection(project) {
 
     private val fastModeCheckbox = JCheckBox("Skip sanity checks")
     private val skipStringNormalCheckbox = JCheckBox("Skip string normalization")
+    private val skipMagicTrailingCommaCheckbox = JCheckBox("Don't use trailing commas as a reason to split lines.")
     private val targetSpecificVersionsCheckbox = JCheckBox("Target specific Python versions")
 
     private val targetVersions = mapOf(
@@ -98,6 +99,7 @@ class FormattingSection(private val project: Project) : ConfigSection(project) {
 
         lineLengthSpinner.value = blackSettings.getLong("line-length", DEFAULT_LINE_LENGTH.toLong()).toInt()
         skipStringNormalCheckbox.isSelected = blackSettings.getBoolean("skip-string-normalization", false)
+        skipMagicTrailingCommaCheckbox.isSelected = blackSettings.getBoolean("skip-magic-trailing-comma", false)
         fastModeCheckbox.isSelected = blackSettings.getBoolean("fast", false)
     }
 
@@ -128,6 +130,7 @@ class FormattingSection(private val project: Project) : ConfigSection(project) {
                     .addLabeledComponent("Line length:", lineLengthPanel)
                     .addComponent(fastModeCheckbox)
                     .addComponent(skipStringNormalCheckbox)
+                    .addComponent(skipMagicTrailingCommaCheckbox)
                     .addComponent(targetSpecificVersionsCheckbox)
                     .addComponent(targetVersionsPanel)
                     .addComponent(loadPyprojectTomlButton)
@@ -184,6 +187,7 @@ class FormattingSection(private val project: Project) : ConfigSection(project) {
         lineLengthSpinner.value = configuration.lineLength
         fastModeCheckbox.isSelected = configuration.fastMode
         skipStringNormalCheckbox.isSelected = configuration.skipStringNormalization
+        skipMagicTrailingCommaCheckbox.isSelected = configuration.skipMagicTrailingComma
 
         configuration.pythonTargets.split(",").forEach { version ->
             versionCheckboxes[version]?.isSelected = true
@@ -208,6 +212,7 @@ class FormattingSection(private val project: Project) : ConfigSection(project) {
         configuration.lineLength = lineLengthSpinner.value as Int
         configuration.fastMode = fastModeCheckbox.isSelected
         configuration.skipStringNormalization = skipStringNormalCheckbox.isSelected
+        configuration.skipMagicTrailingComma = skipMagicTrailingCommaCheckbox.isSelected
         configuration.targetSpecificVersions = targetSpecificVersionsCheckbox.isSelected
         configuration.pythonTargets = generateVersionSpec()
     }
@@ -216,6 +221,7 @@ class FormattingSection(private val project: Project) : ConfigSection(project) {
         return lineLengthSpinner.value != configuration.lineLength ||
             fastModeCheckbox.isSelected != configuration.fastMode ||
             skipStringNormalCheckbox.isSelected != configuration.skipStringNormalization ||
+            skipMagicTrailingCommaCheckbox.isSelected != configuration.skipMagicTrailingComma ||
             targetSpecificVersionsCheckbox.isSelected != configuration.targetSpecificVersions ||
             generateVersionSpec() != configuration.pythonTargets
     }

--- a/src/main/kotlin/me/lensvol/blackconnect/settings/BlackConnectProjectSettings.kt
+++ b/src/main/kotlin/me/lensvol/blackconnect/settings/BlackConnectProjectSettings.kt
@@ -37,6 +37,9 @@ class BlackConnectProjectSettings : PersistentStateComponent<BlackConnectProject
     var skipStringNormalization: Boolean = false
 
     @Attribute
+    var skipMagicTrailingComma: Boolean = false
+
+    @Attribute
     var triggerOnEachSave: Boolean = false
 
     @Attribute


### PR DESCRIPTION
The new version of Black brings the following changes that are relevant to us:

* New option to skip breaking up lines based on "magic trailing comma" (c)
* User can now choose Python 3.9 as a possible target version.

This PR is meant to support that in the plugin, at the same time making it obvious if some new option is used on the _older_ version of Black. Unfortunately, `blackd` will silently ignore any unknown HTTP headers in the request. We could work around that by checking returned Black version in the response, but it will mean additional complexity. :(