### PR TITLE
Fix line indentation on reformatting changed lines with blackconnect

### DIFF
--- a/src/main/kotlin/me/lensvol/blackconnect/BlackPostFormatProcessor.kt
+++ b/src/main/kotlin/me/lensvol/blackconnect/BlackPostFormatProcessor.kt
@@ -7,6 +7,7 @@ import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
 import com.intellij.psi.codeStyle.CodeStyleSettings
 import com.intellij.psi.impl.source.codeStyle.PostFormatProcessor
+import com.intellij.psi.impl.source.codeStyle.CodeStyleManagerImpl
 import me.lensvol.blackconnect.settings.BlackConnectProjectSettings
 
 /**
@@ -38,7 +39,11 @@ class BlackPostFormatProcessor : PostFormatProcessor {
         )
         val blackened = response as? BlackdResponse.Blackened ?: return rangeToReformat
         source.replaceAndCommit(fixedRange, blackened.sourceCode)
-        return TextRange.from(fixedRange.startOffset, blackened.sourceCode.length)
+        val blackenedRange = TextRange.from(fixedRange.startOffset, blackened.sourceCode.length)
+        // Fix line indentation so that the fragment result from black respects the current indentation
+        CodeStyleManagerImpl(source.project).adjustLineIndent(source, blackenedRange)
+
+        return blackenedRange
     }
 
     private fun isApplicable(source: PsiFile): Boolean {

--- a/src/test/kotlin/me/lensvol/blackconnect/PostFormatTestCase.kt
+++ b/src/test/kotlin/me/lensvol/blackconnect/PostFormatTestCase.kt
@@ -94,4 +94,31 @@ class PostFormatTestCase {
             """.trimIndent()
         )
     }
+
+    @Test
+    fun `test reformat fragment with Black end of file, respects indents`() = runInEdtAndWait {
+        fixture.blackSettings.triggerOnReformat = true
+        fixture.configureByText(
+            "a.py",
+            """
+            class Foo:
+                def bar(self):
+                    <selection>g(1,2,3,)</selection>
+ 
+            """.trimIndent()
+        )
+        fixture.performEditorAction(IdeActions.ACTION_EDITOR_REFORMAT)
+        fixture.checkResult(
+            """
+            class Foo:
+                def bar(self):
+                    g(
+                        1,
+                        2,
+                        3,
+                    )
+ 
+            """.trimIndent()
+        )
+    }
 }

--- a/src/test/kotlin/me/lensvol/blackconnect/PostFormatTestCase.kt
+++ b/src/test/kotlin/me/lensvol/blackconnect/PostFormatTestCase.kt
@@ -96,7 +96,7 @@ class PostFormatTestCase {
     }
 
     @Test
-    fun `test reformat fragment with Black end of file, respects indents`() = runInEdtAndWait {
+    fun `test reformat fragment with Black respects indents`() = runInEdtAndWait {
         fixture.blackSettings.triggerOnReformat = true
         fixture.configureByText(
             "a.py",
@@ -116,6 +116,36 @@ class PostFormatTestCase {
                         1,
                         2,
                         3,
+                    )
+ 
+            """.trimIndent()
+        )
+    }
+
+
+    @Test
+    fun `test reformat long line with Black respects line length`() = runInEdtAndWait {
+        fixture.blackSettings.triggerOnReformat = true
+        fixture.blackSettings.lineLength = 80
+        // The selected print line in the editor is just over 80 char if you also count the
+        // indents. We expect black to pick up the indentation so it can correctly see the
+        // line length.
+        fixture.configureByText(
+            "a.py",
+            """
+            class Foo:
+                def bar(self):
+                    <selection>print("Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod")</selection>
+ 
+            """.trimIndent()
+        )
+        fixture.performEditorAction(IdeActions.ACTION_EDITOR_REFORMAT)
+        fixture.checkResult(
+            """
+            class Foo:
+                def bar(self):
+                    print(
+                        "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod"
                     )
  
             """.trimIndent()


### PR DESCRIPTION
Use case: I work in larger legacy codebases in which I don't want to reformat an entire file when I make a change. So I have pycharm configured to only reformat the changed code on save. And then have blackconnect trigger on code reformat. This way I can have blackd reformat only my code changes, while leaving the rest of the file unharmed. This currently doesn't work, there are cases when I change small fragments of existing code and the indentation breaks.

This PR adds a test to show what I mean :) and also provides a fix. I must say in honesty that this is the first time I'm changing an Intellij plugin so I may not do the right thing. I'm happy to further improve this work based on your feedback @lensvol .

Thanks a lot for this amazing plugin! 