### PR TITLE
Fix broken link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 Simple plugin for IDEA intended to help you to avoid overhead from starting [black](https://github.com/psf/black) process each time you save a Python file.
 
-Instead, on each press of `Alt + Shift + B` plugin will send contents of the current Python file to the [blackd](https://black.readthedocs.io/en/stable/blackd.html) and replace them with the formatted version (if any changes were made at all).
+Instead, on each press of `Alt + Shift + B` plugin will send contents of the current Python file to the [blackd](https://black.readthedocs.io/en/stable/usage_and_configuration/black_as_a_server.html) and replace them with the formatted version (if any changes were made at all).
 
 ## Features
 


### PR DESCRIPTION
SSIA.

Link of `blackd` should be https://black.readthedocs.io/en/stable/usage_and_configuration/black_as_a_server.html.