### PR TITLE
Fix PIP command for MacOS shell

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -29,7 +29,7 @@
 
     <p><b>Steps to use:</b></p>
     <ol>
-      <li><b>pip install black[d]</b></li>
+      <li><b>pip install "black[d]"</b></li>
       <li>Start <b>blackd</b> daemon.</li>
       <li>Press "Alt + Shift + B" to reformat your code...<br>...or enable "on file save" option.</li>
       <li>Enjoy!</li>


### PR DESCRIPTION
For me on MacOS I must quote the package name in `pip install black[d]` so the mac's shell honors the true name of the package, and specifically its brackets as literals: `pip install "black[d]"`

TESTING

* MacOS 13, bash shell